### PR TITLE
[Bug Fix] Skeletonの高さでコメントリスト表示の高さが合わなくなる問題を修正

### DIFF
--- a/components/Card/AuthorCard.module.css
+++ b/components/Card/AuthorCard.module.css
@@ -1,5 +1,6 @@
 .comment {
   padding: var(--mantine-spacing-lg) var(--mantine-spacing-xl);
+  min-height: 108px;
 }
 
 .body {

--- a/components/Card/AuthorCard.tsx
+++ b/components/Card/AuthorCard.tsx
@@ -13,7 +13,7 @@ export function AuthorCard() {
 
   return (
     <>
-      <Skeleton height={102} visible={!isFetched}>
+      <Skeleton visible={!isFetched}>
         <Paper withBorder radius="md" className={classes.comment}>
           <Group>
             <Text fz="lg">


### PR DESCRIPTION
## 概要
Skeletonで高さを指定していると、Skeletonの中身が変更されてもSkeletonの高さが永続する。そのため、Mantine hooksで取得していた高さもこの高さになり、結果としてコメントリストの高さが合わなくなっていた模様。  
この問題を修正。
## 競合情報
なし