### PR TITLE
[Feature] サービス稼働状況をリンクするように

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,6 @@ NEXT_PUBLIC_SITE_DESCRIPTION = 'Vコレ特設Webサイト'
 
 # 表示シーズンID
 NEXT_PUBLIC_VISIBLE_SEASON_ID = 3
+
+# ステータスモニタリング用URL (UptimeRobotによる障害発生監視)
+NEXT_PUBLIC_STATUS_URL = 'https://stats.uptimerobot.com/Mlw9XHxvDr'

--- a/components/Footer/FooterLinks.module.css
+++ b/components/Footer/FooterLinks.module.css
@@ -86,6 +86,7 @@
 .right {
   display: flex;
   text-align: right;
+  flex-direction: column;
 
   @media (max-width: $mantine-breakpoint-xs) {
     width: 100%;
@@ -120,4 +121,12 @@
   @media (min-width: $mantine-breakpoint-md) {
     display: none;
   }
+}
+
+.anchor {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  flex-wrap: nowrap;
+  flex-direction: row;
 }

--- a/components/Footer/FooterLinks.tsx
+++ b/components/Footer/FooterLinks.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { Text, Container, ActionIcon, Group, Button, rem } from '@mantine/core';
-import { IconBrandTwitterFilled, IconArrowBack } from '@tabler/icons-react';
+import { Text, Container, ActionIcon, Group, Button, rem, Anchor } from '@mantine/core';
+import { IconBrandTwitterFilled, IconArrowBack, IconGraph } from '@tabler/icons-react';
 import classes from './FooterLinks.module.css';
 
 const url = process.env.NEXT_PUBLIC_BASE_URL;
+const statusUrl = process.env.NEXT_PUBLIC_STATUS_URL;
 const text = 'Vコレを一緒に盛り上げよう！';
 
 //呼び出されたら出力する場所
@@ -73,15 +74,30 @@ export function FooterLinks() {
           </Group>
 
           <div className={classes.right}>
-            <Text c="dark" style={{ fontSize: 14 }} className={classes.copyright}>
+            <Text c="dark" className={classes.copyright} style={{ fontSize: 14 }}>
               「VOCALOID（ボーカロイド）」ならびに
-              <br className={classes.tbBr} />
+              <br className={classes.spBr} />
               「ボカロ」はヤマハ株式会社の登録商標です。
-              <br className={classes.tbBr} />
-              <br />
+            </Text>
+            <Text c="dark" className={classes.copyright} mt={8} style={{ fontSize: 14 }}>
               © 2023 VOCALOID CLUB COLLECTION.&nbsp;
               <br className={classes.spBr} />
-              複製・転載等を固く禁じます
+              複製・転載等を固く禁じます。
+            </Text>
+            <Text c="dark" className={classes.copyright} mt={8}>
+              <Button
+                component="a"
+                href={statusUrl}
+                target="_blank"
+                c="dark"
+                style={{ fontSize: 14 }}
+                className={classes.anchor}
+                variant="transparent"
+                size="compact-md"
+              >
+                <IconGraph />
+                サービス稼働状況
+              </Button>
             </Text>
           </div>
         </Container>


### PR DESCRIPTION
## 概要
さすがに見れない状況が続いてしまったため、障害が起こったときに、何が起こっているのかを公開するようにリンク。  
Discord で使っていたものを使用。  
サーバー（対処不可能な不可抗力）なのか画像（修正可能で対処中）なのかを見れるように。  
注：画像はすべての画像ではなく No.5 をモニタしている。  

![image](https://github.com/vocaken-tdu/v-collection-app/assets/73014392/82325357-b812-4c75-b947-7bac22e60094)

https://stats.uptimerobot.com/Mlw9XHxvDr

## 競合情報
なし