### PR TITLE
[Feature] 画像/リスト取得不可時の通知自動撤去を無効ではなく6秒に設定

### DIFF
--- a/store/illustListStore.tsx
+++ b/store/illustListStore.tsx
@@ -73,7 +73,7 @@ export const setIllustList = async () => {
     notifications.show({
       id: 'fetchFailedIllustList',
       loading: true,
-      autoClose: false,
+      autoClose: 6000,
       radius: 'md',
       title: 'イラスト情報が取得できませんでした。',
       message:

--- a/store/illustStore.tsx
+++ b/store/illustStore.tsx
@@ -44,7 +44,7 @@ export const setIllust = async (illustId: number) => {
     notifications.show({
       id: 'fetchFailedIllust',
       loading: true,
-      autoClose: false,
+      autoClose: 6000,
       radius: 'md',
       title: 'イラスト情報が取得できませんでした。',
       message:


### PR DESCRIPTION
## 概要
正しく取得できる場合もこれが表示される場合、「永遠に通知が閉じない」というユーザー的には不可解な現象が起こるため、多少煩わしい。  
これを軽減するために6秒で自動撤去するように設定。

## 競合情報
なし