### PR TITLE
[Fix] イラストリストをシーズンでソートすることでデータをグループ化

### DIFF
--- a/store/illustListStore.ts
+++ b/store/illustListStore.ts
@@ -81,7 +81,11 @@ export const setIllustList = async () => {
         (item: { tags: [number] }) => item.tags[0] <= visibleSeasonId
       );
 
-      const data = dataFilter.sort((a: any, b: any) => b.id - a.id);
+      // IDで降順ソート
+      const dataOrdered = dataFilter.sort((a: any, b: any) => b.id - a.id);
+
+      // シーズンでソート
+      const data = dataOrdered.sort((a: any, b: any) => b.tags[0] - a.tags[0]);
 
       // ローカルのイラストリストと取得したイラストリストを比較(更新の必要性を判定)
       const dataStr = JSON.stringify(data);


### PR DESCRIPTION
## 概要
フロントエンド側でデータをグループ化してStoreすることで、途中に冬の画像を保存してもシーズンでグループ化されるため、 prev/next のリンクが 夏←冬←夏 とならないようになる。  
ID順ではなく、ID順だけどシーズンでまとめることを優先する
## 競合情報
ほかのデータ加工にソートされていないため、多分なし